### PR TITLE
refactor: centralize student info in data file

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -10,23 +10,23 @@ chapter: false
 
 
 ### Student Information:
-&emsp; **Full Name:** Nguyen Van Truong 
+&emsp; **Full Name:** {{< student field="full_name" >}}
 
-&emsp; **Phone Number:** 0764648648 
+&emsp; **Phone Number:** {{< student field="phone" >}}
 
-&emsp; **Email:** truongnvops@gmail.com
+&emsp; **Email:** {{< student field="email" >}}
 
-&emsp; **University:** FPT University Ho Chi Minh
+&emsp; **University:** {{< student field="university" >}}
 
-&emsp; **Major:** Cyber Security
+&emsp; **Major:** {{< student field="major" >}}
 
-&emsp; **Class:** AWS082025
+&emsp; **Class:** {{< student field="class" >}}
 
-&emsp; **Internship Company:** Amazon Web Services Vietnam Co., Ltd.
+&emsp; **Internship Company:** {{< student field="company" >}}
 
-&emsp; **Internship Position:** FCJ Cloud Intern
+&emsp; **Internship Position:** {{< student field="position" >}}
 
-&emsp; **Internship Duration:** From 8/9/2025 to 12/11/2025
+&emsp; **Internship Duration:** {{< student field="duration" >}}
 
 ![Your profile picture](/images/avatar.jpg)
 
@@ -40,3 +40,4 @@ chapter: false
 5.  [Workshop](5-Workshop/)
 6.  [Self-evaluation](6-Self-evaluation/)
 7.  [Sharing and Feedback](7-Feedback/)
+

--- a/content/_index.vi.md
+++ b/content/_index.vi.md
@@ -7,26 +7,25 @@ chapter: false
 
 # Báo cáo thực tập
 ### Thông tin sinh viên:
-&emsp; **Họ và tên:** Nguyễn Văn Trường 
+&emsp; **Họ và tên:** {{< student field="full_name" >}}
 
-&emsp; **Số điện thoại:** 0989888999
+&emsp; **Số điện thoại:** {{< student field="phone" >}}
 
-&emsp; **Email:** Anguyenvan@gmail.com
+&emsp; **Email:** {{< student field="email" >}}
 
-&emsp; **Trường:** Đại học Sư phạm Kỹ thuật TP.HCM
+&emsp; **Trường:** {{< student field="university" >}}
 
-&emsp; **Ngành:** Công nghệ thông tin
+&emsp; **Ngành:** {{< student field="major" >}}
 
-&emsp; **Lớp:** AWS082025
+&emsp; **Lớp:** {{< student field="class" >}}
 
-&emsp; **Công ty thực tập:** Công ty TNHH Amazon Web Services Vietnam
+&emsp; **Công ty thực tập:** {{< student field="company" >}}
 
-&emsp; **Vị trí thực tập:** FCJ Cloud Intern
+&emsp; **Vị trí thực tập:** {{< student field="position" >}}
 
-&emsp; **Thời gian thực tập:** Từ ngày 12/08/2025 đến ngày 12/11/2025
+&emsp; **Thời gian thực tập:** {{< student field="duration" >}}
 
-![Ảnh đại diện của bạn](static\images\avatar.png)
-
+![Ảnh đại diện của bạn](/images/avatar.jpg)
 
 
 ### Nội dung báo cáo
@@ -38,3 +37,4 @@ chapter: false
 5.  [Workshop](5-Workshop/)
 6.  [Tự đánh giá](6-Self-evaluation/)
 7.  [Chia sẻ, đóng góp ý kiến](7-Feedback/)
+

--- a/data/student.yaml
+++ b/data/student.yaml
@@ -1,0 +1,27 @@
+full_name:
+  en: "Nguyen Van Truong"
+  vi: "Nguyễn Văn Trường"
+phone:
+  en: "0764648648"
+  vi: "0764648648"
+email:
+  en: "truongnvops@gmail.com"
+  vi: "truongnvops@gmail.com"
+university:
+  en: "FPT University Ho Chi Minh"
+  vi: "Đại học FPT Hồ Chí Minh"
+major:
+  en: "Cyber Security"
+  vi: "An ninh mạng"
+class:
+  en: "AWS082025"
+  vi: "AWS082025"
+company:
+  en: "Amazon Web Services Vietnam Co., Ltd."
+  vi: "Công ty TNHH Amazon Web Services Vietnam"
+position:
+  en: "FCJ Cloud Intern"
+  vi: "FCJ Cloud Intern"
+duration:
+  en: "From 12/08/2025 to 12/11/2025"
+  vi: "Từ ngày 12/08/2025 đến ngày 12/11/2025"

--- a/layouts/shortcodes/student.html
+++ b/layouts/shortcodes/student.html
@@ -1,0 +1,4 @@
+{{- $field := .Get "field" -}}
+{{- $data := site.Data.student -}}
+{{- $lang := .Page.Lang -}}
+{{- index (index $data $field) $lang -}}


### PR DESCRIPTION
## Summary
- centralize student details in `data/student.yaml`
- add `student` shortcode to load shared data
- update English and Vietnamese home pages to use shortcode and unify contact info

## Testing
- `hugo --printI18nWarnings` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0531f183883259cf64c9c7106b5be